### PR TITLE
Update BL602-hal to embedded-1.0.0-Alpha5 commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 riscv-rt = "0.8.0"
-bl602-hal = { git = "https://github.com/sipeed/bl602-hal", rev="0ccf19d31e7f89ed5d045a80fab6393e41db6bb4" }
+embedded-hal = "=1.0.0-alpha.5"
+bl602-hal = { git = "https://github.com/sipeed/bl602-hal", rev="dfc9946e79ea4dac18be11efce11d0592a8517fb" }
 panic-halt = "0.2.0"
 riscv = "0.6.0"
 embedded-time = "0.10.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use hal::{
     prelude::*,
     serial::*,
 };
+use embedded_hal::delay::blocking::DelayMs;
+use embedded_hal::digital::blocking::OutputPin;
 use panic_halt as _;
 
 #[riscv_rt::entry]
@@ -45,12 +47,12 @@ fn main() -> ! {
 
     loop {
         // Toggle the LED on and off once a second. Report LED status over UART
-        gpio5.try_set_high().unwrap();
+        gpio5.set_high().unwrap();
         serial.write_str("LEDs on\r\n").ok();
-        d.try_delay_ms(1000).unwrap();
+        d.delay_ms(1000).unwrap();
 
-        gpio5.try_set_low().unwrap();
+        gpio5.set_low().unwrap();
         serial.write_str("LEDs off\r\n").ok();
-        d.try_delay_ms(1000).unwrap();
+        d.delay_ms(1000).unwrap();
     }
 }


### PR DESCRIPTION
When I first tried to compile, I ran into errors with the try_set_*() functions, so I updated a couple things so that this will work using the [latest commit from the bl602-hal repo](https://github.com/sipeed/bl602-hal/commit/dfc9946e79ea4dac18be11efce11d0592a8517fb) that has the embedded-hal-1.0.0-Alpha5 integrated into it. It now compiles right out of the box with these changes, at least for me.

This is my first time working officially with embedded rust and this code base, so please let me know if any of my changes would make more sense if done differently.